### PR TITLE
mettle is not compatible with pika version 0.10.0 or greater

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ params = dict(
 
         # leave mettle-protocol and its dependencies loosely versioned.
         'mettle-protocol>=1.0.1',
-        'pika>=0.9.14,<=0.10.0',
+        'pika>=0.9.14,<0.10.0',
         'utc',
     ],
     extras_require={


### PR DESCRIPTION
We've found earlier today that installing pika version 0.10.0 is not compatible with actual mettle's codebase.

`TypeError: exchange_declare() got an unexpected keyword argument 'type'`

I relaxed pika dependency to install only 0.9.x releases and now a new release is needed.

Next step is to make mettle work with most recent pika versions, but we need to fix this bug first.